### PR TITLE
feat(tech): replace deprecated rc-progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"next": "^13.4.3",
-				"rc-progress": "^3.4.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-icons": "^4.4.0",
@@ -3032,11 +3031,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/classnames": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5746,38 +5740,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/rc-progress": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.4.2.tgz",
-			"integrity": "sha512-iAGhwWU+tsayP+Jkl9T4+6rHeQTG9kDz8JAHZk4XtQOcYN5fj9H34NXNEdRdZx94VUDHMqCb1yOIvi8eJRh67w==",
-			"dependencies": {
-				"@babel/runtime": "^7.10.1",
-				"classnames": "^2.2.6",
-				"rc-util": "^5.16.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-util": {
-			"version": "5.31.1",
-			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.31.1.tgz",
-			"integrity": "sha512-ecgQsqv7j0ZTNMsQU1M/xLBnboSoiJxwE9R0rQEe0MaxOCZmhTTCjDP+6KPQjTaXlyIkVuZT3lC4CNkr+cp9Lw==",
-			"dependencies": {
-				"@babel/runtime": "^7.18.3",
-				"react-is": "^16.12.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-util/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/react": {
 			"version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	},
 	"dependencies": {
 		"next": "^13.4.3",
-		"rc-progress": "^3.4.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-icons": "^4.4.0",

--- a/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
@@ -38,7 +38,6 @@ export const DonatePageContent: NextPage<DonationPageProps> = ({ cms }: Donation
 	const [iFrameLoading, setIFrameLoaded] = useState(true)
 	const [iFrameError, setIFrameError] = useState(false)
 	const languageContext = useLanguageContext()
-	const [hasReachedGoal, setHasReachGoal] = useState(false)
 	const ipInfoContext = useContext(IpInfoProviderContext)
 	const [shouldDisplayTaxHint, setShouldDisplayTaxHint] = useState(false)
 
@@ -116,14 +115,6 @@ export const DonatePageContent: NextPage<DonationPageProps> = ({ cms }: Donation
 	const iFrameLoadedError = useCallback(() => {
 		setIFrameError(true)
 	}, [])
-
-	useEffect(() => {
-		if (progressPercentage >= 100) {
-			setHasReachGoal(true)
-		} else {
-			setHasReachGoal(false)
-		}
-	}, [progressPercentage])
 
 	useEffect(() => {
 		if (wishCountry === 'DE' && ipInfoContext.country === 'AT') {

--- a/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
@@ -147,7 +147,7 @@ export const DonatePageContent: NextPage<DonationPageProps> = ({ cms }: Donation
 								<Text content="donationPrependText" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationSum)}</DonationStatNumbers>
 							</p>
-							<ProgressBar percent={progressPercentage}></ProgressBar>
+							<ProgressBar percent={progressPercentage} style={{ margin: '4px 0px' }}></ProgressBar>
 							<DonationStatsWidgetGoal>
 								<Text content="donationGoal" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationGoal)}</DonationStatNumbers>
@@ -342,7 +342,6 @@ const DonationStatsWidget = styled.div`
 `
 
 const DonationStatsWidgetGoal = styled.p`
-	margin-top: -5px;
 	text-align: right;
 `
 

--- a/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
@@ -147,7 +147,7 @@ export const DonatePageContent: NextPage<DonationPageProps> = ({ cms }: Donation
 								<Text content="donationPrependText" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationSum)}</DonationStatNumbers>
 							</p>
-							<ProgressBar percent={progressPercentage} style={{ margin: '4px 0px' }}></ProgressBar>
+							<ProgressBar percent={progressPercentage} style={{ margin: '4px 0px' }} />
 							<DonationStatsWidgetGoal>
 								<Text content="donationGoal" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationGoal)}</DonationStatNumbers>

--- a/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/content.tsx
@@ -1,7 +1,5 @@
 'use client'
 import { NextPage } from 'next'
-//** TODO: deprecate rc-progress and implement a custom component */
-import { Line } from 'rc-progress'
 import React, { useState, useContext, useEffect, useCallback } from 'react'
 import { BsFillPeopleFill } from 'react-icons/bs'
 import { FaDove } from 'react-icons/fa'
@@ -26,6 +24,7 @@ import { useLanguageContext } from '../../../../provider/LanguageProvider'
 import { hasProperty, getPercentage } from '../../../../utils/commonUtils'
 import { formatMoneyWithSign, formatDate } from '../../../../utils/formatUtils'
 import { ImTrophy } from 'react-icons/im'
+import ProgressBar from './progress-bar'
 
 export interface DonationPageProps {
 	cms: {
@@ -157,17 +156,7 @@ export const DonatePageContent: NextPage<DonationPageProps> = ({ cms }: Donation
 								<Text content="donationPrependText" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationSum)}</DonationStatNumbers>
 							</p>
-							{
-								//** TODO: deprecate rc-progress and implement a custom component */
-							}
-							<Line
-								style={{ padding: '4px 0' }}
-								percent={progressPercentage}
-								strokeWidth={4}
-								trailWidth={4}
-								trailColor="white"
-								strokeColor={hasReachedGoal && !makeAWishDataIsLoading ? 'green' : 'gold'}
-							/>
+							<ProgressBar percent={progressPercentage}></ProgressBar>
 							<DonationStatsWidgetGoal>
 								<Text content="donationGoal" />{' '}
 								<DonationStatNumbers>{formatMoneyWithSign(donationGoal)}</DonationStatNumbers>

--- a/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { styled } from 'styled-components'
 
 interface ProgressBarProps {
+	style: React.CSSProperties
 	percent: number
 }
 
@@ -30,11 +31,11 @@ function normalizePercentage(percentage: number): number {
 	return Math.max(0, Math.min(percentage, 100))
 }
 
-const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ percent }: ProgressBarProps) => {
+const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ style, percent }: ProgressBarProps) => {
 	const normalizedPercentage = normalizePercentage(percent)
 
 	return (
-		<ProgressBarContainer>
+		<ProgressBarContainer style={style}>
 			<Bar progress={normalizedPercentage}></Bar>
 		</ProgressBarContainer>
 	)

--- a/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
@@ -1,25 +1,10 @@
 import React from 'react'
-import { styled } from 'styled-components'
+import { keyframes, styled } from 'styled-components'
 
 interface ProgressBarProps {
 	style: React.CSSProperties
 	percent: number
 }
-
-const ProgressBarContainer = styled.div`
-	background-color: white;
-	width: 100%;
-	height: 12px;
-	border-radius: 6px;
-`
-const Bar = styled.div<{ progress: number }>`
-	background-color: ${(props) => (props.progress < 100 ? 'gold' : 'green')};
-	width: ${(props) => props.progress}%;
-	min-width: 12px;
-	height: 12px;
-	border-radius: 6px;
-	transition: width 400ms ease-in-out;
-`
 
 /**
  * Normalizes a given percentage value to be between 0 and 100.
@@ -41,5 +26,33 @@ const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ style, percent
 		</ProgressBarContainer>
 	)
 }
+
+const progressAnimation = (progress: number) => keyframes`
+	0% {
+		width: 12px;
+		background-color: gold;
+	}
+	90% {
+		width: ${progress}%;
+		background-color: gold;
+	}
+	100% {
+		width: ${progress}%;
+		background-color: ${progress >= 100 ? 'green' : 'gold'};
+	}
+`
+
+const ProgressBarContainer = styled.div`
+	background-color: white;
+	width: 100%;
+	height: 12px;
+	border-radius: 6px;
+`
+const Bar = styled.div<{ progress: number }>`
+	min-width: 12px;
+	height: 12px;
+	border-radius: 6px;
+	animation: ${(props) => progressAnimation(props.progress)} 400ms forwards ease-in-out;
+`
 
 export default ProgressBar

--- a/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
@@ -14,6 +14,7 @@ const ProgressBarContainer = styled.div`
 const Bar = styled.div<{ progress: number }>`
 	background-color: ${(props) => (props.progress < 100 ? 'gold' : 'green')};
 	width: ${(props) => props.progress}%;
+	min-width: 12px;
 	height: 12px;
 	border-radius: 6px;
 `

--- a/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
@@ -18,6 +18,7 @@ const Bar = styled.div<{ progress: number }>`
 	min-width: 12px;
 	height: 12px;
 	border-radius: 6px;
+	transition: width 400ms ease-in-out;
 `
 
 /**

--- a/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
+++ b/src/app/(site)/[streamer]/[wishSlug]/components/progress-bar.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { styled } from 'styled-components'
+
+interface ProgressBarProps {
+	percent: number
+}
+
+const ProgressBarContainer = styled.div`
+	background-color: white;
+	width: 100%;
+	height: 12px;
+	border-radius: 6px;
+`
+const Bar = styled.div<{ progress: number }>`
+	background-color: ${(props) => (props.progress < 100 ? 'gold' : 'green')};
+	width: ${(props) => props.progress}%;
+	height: 12px;
+	border-radius: 6px;
+`
+
+/**
+ * Normalizes a given percentage value to be between 0 and 100.
+ * It basically caps values lower than 0 or higher than 100.
+ *
+ * @param percentage a not yet normalized percentage value that can exceed 100.
+ * @returns a value between 0 and 100.
+ */
+function normalizePercentage(percentage: number): number {
+	return Math.max(0, Math.min(percentage, 100))
+}
+
+const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ percent }: ProgressBarProps) => {
+	const normalizedPercentage = normalizePercentage(percent)
+
+	return (
+		<ProgressBarContainer>
+			<Bar progress={normalizedPercentage}></Bar>
+		</ProgressBarContainer>
+	)
+}
+
+export default ProgressBar


### PR DESCRIPTION
A new progress bar component has been introduced that replaces the deprecated rc-progress component. Styling was mostly moved to the component, since it's cut for this concrete use case. Only a single prop is exposed to control the progress.

Fixes #105