### PR TITLE
129: only display scheduled live channels

### DIFF
--- a/src/app/cms/components/StreamSchedule/StreamSchedule.tsx
+++ b/src/app/cms/components/StreamSchedule/StreamSchedule.tsx
@@ -18,6 +18,7 @@ import {
 	StyledPast,
 } from '../../../../styles/common.styles'
 import { LiveChannels } from './LiveChannels'
+import { useLiveChannels } from '../../../hooks/useLiveChannels'
 
 interface StreamScheduleProps {
 	schedules: CmsSchedulesType
@@ -65,9 +66,11 @@ export const StreamSchedule: React.FunctionComponent<StreamScheduleProps> = ({ s
 		setScheduleType(e.currentTarget.value as StreamerType)
 	}, [])
 
+	const { liveChannelsData } = useLiveChannels();
+
 	return (
 		<React.Fragment>
-			<LiveChannels />
+			{liveChannelsData.length > 0 && <LiveChannels />}
 			{futureStreamsSorted.length > 0 && (
 				<React.Fragment>
 					<StyleUpcomingStreamsHeader>


### PR DESCRIPTION
Only the live channels that are scheduled between now and now+24h will be displayed on the main page. If none of these channels are live currently, the entire section will be hidden.